### PR TITLE
DOC: change list to tuple in example description (Closes #15699)

### DIFF
--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -1112,8 +1112,8 @@ indices for each dimension must have the same shape.
            [[10,  9],
             [11, 11]]])
 
-Naturally, we can put ``i`` and ``j`` in a sequence (say a list) and
-then do the indexing with the list.
+Naturally, we can put ``i`` and ``j`` in a sequence (say a tuple) and
+then do the indexing with the tuple.
 
 ::
 


### PR DESCRIPTION
This PR fixes #15699

Changed a description in the `quickstart` example to use `tuple` instead of the deprecated `list` for indexing arrays.

The change is located at the **Indexing with Arrays of Indices** section.


